### PR TITLE
Improve UI/UX: flash messages, recent-post highlight, breadcrumb, and form validation

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -32,6 +32,8 @@ const App: React.FC = () => {
   const [adminPassInput, setAdminPassInput] = useState('');
   const [isAdminAuthenticated, setIsAdminAuthenticated] = useState(false);
   const [nowMs, setNowMs] = useState(() => Date.now());
+  const [flashMsg, setFlashMsg] = useState<string | null>(null);
+  const [recentPostedId, setRecentPostedId] = useState<string | null>(null);
 
   const isSupabaseMode = !!supabase;
 
@@ -207,6 +209,8 @@ const App: React.FC = () => {
       }
     }
     setNovels([novelToSave, ...novels]);
+    setRecentPostedId(novelToSave.id);
+    setFlashMsg(`>>> 「${novelToSave.title}」を投稿しました。`);
     window.location.hash = '';
   };
 
@@ -229,6 +233,7 @@ const App: React.FC = () => {
       }
     }
     setComments((prev) => [...prev, commentToSave]);
+    setFlashMsg('>>> 感想を受け付けました。');
   };
 
   const handleEditNovel = async (id: string, patch: Pick<Novel, 'title' | 'author' | 'trip' | 'body'>) => {
@@ -327,6 +332,26 @@ const App: React.FC = () => {
     nowMs - latestDeployedAtMs < DEPLOY_HIGHLIGHT_DURATION_MS;
 
   const activeNovel = visibleNovels.find((n) => n.id === activeNovelId);
+  const currentPathLabel = view === 'list'
+    ? 'トップ > 一覧'
+    : view === 'post'
+      ? 'トップ > 新規投稿'
+      : view === 'admin'
+        ? 'トップ > 管理'
+        : `トップ > 一覧 > ${activeNovel?.title ?? '閲覧中'}`;
+
+
+  useEffect(() => {
+    if (!recentPostedId) return;
+    const timer = window.setTimeout(() => setRecentPostedId(null), 15000);
+    return () => window.clearTimeout(timer);
+  }, [recentPostedId]);
+
+  useEffect(() => {
+    if (!flashMsg) return;
+    const timer = window.setTimeout(() => setFlashMsg(null), 3000);
+    return () => window.clearTimeout(timer);
+  }, [flashMsg]);
 
   const handleAdminLogin = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -385,7 +410,8 @@ const App: React.FC = () => {
           <a href="#" style={{ color: '#7a0000', textDecoration: 'none' }}>文章アリの穴NEO</a>
         </h1>
 
-        <div className="header-links">[ <a href="#">トップ</a> ] [ <a href="#post">投稿する</a> ] [ <a href="#admin">管理</a> ] [ <a href="#" onClick={(e) => e.preventDefault()}>検索</a> ] [ <button type="button" className="help-link-btn" onClick={() => setShowHelp(true)}>ヘルプ</button> ] {isAdminAuthenticated && <button type="button" className="help-link-btn" onClick={handleAdminLogout}>[ 管理ログアウト ]</button>}</div>
+        <div className="header-links">[ <a href="#" className={view === 'list' ? 'active-link' : undefined}>トップ</a> ] [ <a href="#post" className={view === 'post' ? 'active-link' : undefined}>投稿する</a> ] [ <a href="#admin" className={view === 'admin' ? 'active-link' : undefined}>管理</a> ] [ <a href="#" onClick={(e) => e.preventDefault()} aria-disabled="true" title="検索機能は準備中です">検索(準備中)</a> ] [ <button type="button" className="help-link-btn" onClick={() => setShowHelp(true)}>ヘルプ</button> ] {isAdminAuthenticated && <button type="button" className="help-link-btn" onClick={handleAdminLogout}>[ 管理ログアウト ]</button>}</div>
+        <div className="breadcrumb-box">現在地: {currentPathLabel}</div>
 
         <div className="site-meta">管理人: <b>アリOB</b> / モード: {isSupabaseMode ? 'オンライン' : 'オフライン'} / 投稿数: {visibleNovels.length}（全{novels.length}）</div>
         <div className="site-meta">
@@ -394,11 +420,12 @@ const App: React.FC = () => {
         </div>
 
         {errorMsg && <div className="error-box">{errorMsg}</div>}
+        {flashMsg && <div className="flash-box" role="status" aria-live="polite">{flashMsg}</div>}
 
         <hr className="top-rule" />
         <div className="marquee-box">2005年のテキスト投稿サイトをオマージュして再現中。感想・評価の書き込み歓迎です。</div>
 
-        {view === 'list' && <NovelList novels={visibleNovels} comments={comments} />}
+        {view === 'list' && <NovelList novels={visibleNovels} comments={comments} recentPostedId={recentPostedId} />}
         {view === 'post' && <PostForm onPost={handlePost} />}
         {view === 'admin' && !isAdminAuthenticated && (
           <div>

--- a/app.css
+++ b/app.css
@@ -54,6 +54,16 @@ a:hover, a:active { color: #cc0000; }
 
 .site-meta { margin-top: 2px; color: #444; }
 
+.active-link { color: #cc0000; font-weight: bold; }
+
+.breadcrumb-box {
+  border: 1px solid var(--line-soft);
+  background: #f7f7f7;
+  font-size: 13px;
+  padding: 3px 6px;
+  margin-top: 4px;
+}
+
 .live-deploy-dot {
   color: #1f61ff;
   margin-left: 8px;
@@ -149,6 +159,26 @@ a:hover, a:active { color: #cc0000; }
 .comment-name { color: #004d00; font-weight: bold; }
 .comment-text { white-space: pre-wrap; }
 
+.error-inline {
+  margin-top: 4px;
+  color: #900;
+  font-size: 12px;
+}
+
+.reader-bottom-nav {
+  margin-top: 14px;
+  padding: 8px;
+  border: 1px solid var(--line-soft);
+  background: #f7f7f7;
+  text-align: center;
+}
+
+.reader-back-button {
+  display: inline-block;
+  text-decoration: none;
+  color: #111;
+}
+
 .form-label { width: 100px; font-weight: bold; font-size: 13px; }
 
 input[type='text'], textarea {
@@ -199,6 +229,19 @@ textarea { width: 100%; }
   font-size: 13px;
 }
 
+.flash-box {
+  margin-top: 4px;
+  border: 1px solid #8ea7d8;
+  background: #f2f7ff;
+  color: #123b84;
+  padding: 3px 5px;
+  font-size: 13px;
+}
+
+.recent-row td {
+  background: #fffce8;
+}
+
 .help-backdrop {
   position: fixed;
   inset: 0;
@@ -231,6 +274,11 @@ textarea { width: 100%; }
 @media (max-width: 640px) {
   .site-title { font-size: 29px; }
   .read-sub { display: block; }
+  .header-links { line-height: 1.9; }
+  .header-links a,
+  .header-links button { margin: 0 2px; }
+  .classic-table th,
+  .classic-table td { padding: 7px 6px; }
 }
 
 .admin-edit-box {

--- a/components/NovelList.tsx
+++ b/components/NovelList.tsx
@@ -5,9 +5,10 @@ import { calculateScore, formatDate } from '../utils';
 interface NovelListProps {
   novels: Novel[];
   comments: Comment[];
+  recentPostedId?: string | null;
 }
 
-export const NovelList: React.FC<NovelListProps> = ({ novels, comments }) => {
+export const NovelList: React.FC<NovelListProps> = ({ novels, comments, recentPostedId = null }) => {
   return (
     <div>
       <div className="section-title">■ 投稿文章一覧</div>
@@ -29,7 +30,7 @@ export const NovelList: React.FC<NovelListProps> = ({ novels, comments }) => {
             const { total, count } = calculateScore(novelComments);
 
             return (
-              <tr key={novel.id}>
+              <tr key={novel.id} className={recentPostedId === novel.id ? 'recent-row' : undefined}>
                 <td style={{ textAlign: 'center' }}>{novels.length - index}</td>
                 <td>
                   <a href={`#read/${novel.id}`} className="novel-title">

--- a/components/NovelReader.tsx
+++ b/components/NovelReader.tsx
@@ -15,15 +15,17 @@ export const NovelReader: React.FC<NovelReaderProps> = ({ novel, comments, onCom
   const [commentName, setCommentName] = useState('');
   const [commentText, setCommentText] = useState('');
   const [vote, setVote] = useState(0);
+  const [error, setError] = useState<string | null>(null);
 
   const { total, count } = calculateScore(comments);
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
     if (commentText.length > MAX_COMMENT_LENGTH) {
-      alert(`コメントが長すぎます (${commentText.length}/${MAX_COMMENT_LENGTH})`);
+      setError(`コメントが長すぎます (${commentText.length}/${MAX_COMMENT_LENGTH})`);
       return;
     }
+    setError(null);
 
     const { name, trip } = generateTrip(commentName);
     onComment({
@@ -37,7 +39,6 @@ export const NovelReader: React.FC<NovelReaderProps> = ({ novel, comments, onCom
 
     setCommentText('');
     setVote(0);
-    alert('感想を受け付けました。');
   };
 
   return (
@@ -90,6 +91,7 @@ export const NovelReader: React.FC<NovelReaderProps> = ({ novel, comments, onCom
               <td className="form-label">名前</td>
               <td>
                 <input type="text" value={commentName} onChange={(e) => setCommentName(e.target.value)} placeholder="名無し" style={{ width: 280, maxWidth: '100%' }} />
+                <div style={{ fontSize: 12, color: '#666' }}>※ トリップを使う場合は「名前#pass」で入力</div>
               </td>
             </tr>
             <tr>
@@ -105,7 +107,8 @@ export const NovelReader: React.FC<NovelReaderProps> = ({ novel, comments, onCom
             <tr>
               <td className="form-label">コメント</td>
               <td>
-                <textarea value={commentText} onChange={(e) => setCommentText(e.target.value)} style={{ minHeight: 100 }} maxLength={MAX_COMMENT_LENGTH} />
+                <textarea value={commentText} onChange={(e) => setCommentText(e.target.value)} style={{ minHeight: 100 }} maxLength={MAX_COMMENT_LENGTH} aria-describedby="comment-error" />
+                {error && <div id="comment-error" className="error-inline">{error}</div>}
                 <div style={{ textAlign: 'right', fontSize: 12, color: '#666' }}>{commentText.length}/{MAX_COMMENT_LENGTH}</div>
               </td>
             </tr>
@@ -118,6 +121,9 @@ export const NovelReader: React.FC<NovelReaderProps> = ({ novel, comments, onCom
           </tbody>
         </table>
       </form>
+      <div className="reader-bottom-nav">
+        <a href="#" className="classic-button reader-back-button">&lt;&lt; 作品一覧へ戻る</a>
+      </div>
     </div>
   );
 };

--- a/components/PostForm.tsx
+++ b/components/PostForm.tsx
@@ -10,13 +10,16 @@ export const PostForm: React.FC<PostFormProps> = ({ onPost }) => {
   const [title, setTitle] = useState('');
   const [name, setName] = useState('');
   const [body, setBody] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const MAX_BODY_LENGTH = 4000;
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
     if (!title || !body) {
-      alert('タイトルと本文は必須です。');
+      setError('タイトルと本文は必須です。');
       return;
     }
+    setError(null);
 
     const { name: authorName, trip } = generateTrip(name);
     onPost({
@@ -57,7 +60,8 @@ export const PostForm: React.FC<PostFormProps> = ({ onPost }) => {
             <tr>
               <td className="form-label">本文</td>
               <td>
-                <textarea value={body} onChange={(e) => setBody(e.target.value)} style={{ minHeight: 260 }} />
+                <textarea value={body} onChange={(e) => setBody(e.target.value)} style={{ minHeight: 260 }} maxLength={MAX_BODY_LENGTH} />
+                <div style={{ textAlign: 'right', fontSize: 12, color: '#666' }}>{body.length}/{MAX_BODY_LENGTH}</div>
               </td>
             </tr>
             <tr>
@@ -70,9 +74,10 @@ export const PostForm: React.FC<PostFormProps> = ({ onPost }) => {
           </tbody>
         </table>
       </form>
+      {error && <div className="error-box">{error}</div>}
 
       <div className="legend-box" style={{ marginTop: 10 }}>
-        ※ HTMLタグは使えません。改行はそのまま保持されます。
+        ※ HTMLタグは使えません。改行はそのまま保持されます。本文は最大4000文字です。
       </div>
     </div>
   );


### PR DESCRIPTION
### Motivation
- Improve user feedback and navigation by surfacing transient messages, current location, and highlighting newly posted items.
- Replace intrusive `alert` dialogs with inline/accessible UI and add client-side length/required checks to prevent bad submissions.
- Make header links reflect current view and mark inactive features as disabled for better UX.

### Description
- Added transient flash messaging state (`flashMsg`) and `recentPostedId` to highlight newly posted rows and show short notices after posting or commenting, with auto-dismiss timers. 
- Introduced breadcrumb label `currentPathLabel` and active link styling (`.active-link`) so the header reflects the current `view`, and marked search as disabled with an `aria-disabled` hint. 
- Replaced several `alert` usages with inline error UI: `PostForm` now uses `error` state, enforces a `MAX_BODY_LENGTH` (4000) and shows a character counter, and `NovelReader` validates comment length showing an inline error and counter instead of `alert`.
- Updated `NovelList` to accept `recentPostedId` and apply a `recent-row` class to newly posted entries, and added CSS for `.flash-box`, `.recent-row`, breadcrumb, responsive header tweaks, and small accessibility improvements (e.g. `aria-live` on flash box).

### Testing
- Built the app (`npm run build`) to verify TypeScript and bundling integrity and the build succeeded. 
- Executed the test suite (`npm test`) and the automated tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc26613b9083248d784da4e648256c)